### PR TITLE
Noah/readme gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,7 @@ build/
 .kotlin
 
 ### IntelliJ IDEA ###
-.idea/modules.xml
-.idea/jarRepositories.xml
-.idea/compiler.xml
-.idea/libraries/
+.idea/
 *.iws
 *.iml
 *.ipr
@@ -41,3 +38,8 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### JavaFX ###
+*.fxml.bak
+*.bss
+*.fxml.java

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cookieClicker
+A Cookie Clicker-like game, where users can login and keep their score, upgrades, and other progress saved in an SQLite Database.
 
+By:
 Thomas Gonda
-
 Daniel Martinez
+Noah Panec

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ By:
 Thomas Gonda
 Daniel Martinez
 Noah Panec
+Jake Walton


### PR DESCRIPTION
- Added description and all names to README
- .gitignore updated to ignore the whole .idea folder and a couple additions for JavaFX, although most things are already covered by gradle's default gitignore.
- we may need to make more additions in the future, but I think this is sufficient for now